### PR TITLE
fix: AlinasMapMod url breaks site regex.

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -39,6 +39,6 @@
         "name": "Alina's Map Mod",
         "author": "AlinaNova21",
         "description": "Adds new milestones and unlockable track sections",
-        "url": "https://railroader.alinanova.dev"
+        "url": "https://railroader.alinanova.dev/"
     }
 ]


### PR DESCRIPTION
Apparently, if theres no `/` after the domain, the regex breaks.